### PR TITLE
treewide: Add script to synchronization OrangeFox sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ### Features:
 
+ - Included script to synchronize OrangeFox sources for supported Android version
+
  - Build OrangeFox without losing time doing ". build/envsetup.sh" and "lunch codename" or changing manually release version
 
  - Help you with exporting OF specific variables
@@ -14,9 +16,21 @@
 
 ### "How can I use it?"
 
- - Clone this repo to the root of OrangeFox sources
+ - Clone this repository
 
  - Give to scripts executing permissions
+
+ - Install Android build environment
+   <pre><code>bash setup/env.sh</code></pre>
+
+ - Synchronize OrangeFox sources
+
+   * Android 7.1 -> fox_7.1.sh
+   * Android 8.1 -> fox.8.1.sh
+   * Android 9.0 -> fox_9.0.sh
+
+   Example for Android 9.0 version:
+   <pre><code>bash setup/fox_9.0.sh</code></pre>
 
  - Create a file containing device-specific variables and put it in 
 <pre><code>OF_ROOT/configs/CODENAME_ofconfig</code></pre>

--- a/setup/env.sh
+++ b/setup/env.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# OrangeFox building script by SebaUbuntu
+# Android Build Environment by akhilnarang
+
+# Setup build environment
+git clone https://github.com/akhilnarang/scripts
+bash setup/android_build_env.sh

--- a/setup/fox_7.1.sh
+++ b/setup/fox_7.1.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# OrangeFox building script by SebaUbuntu
+# OrangeFox repo sync script by TheSync
+# Sync OrangeFox sources for Android 7.1
+
+# Sync OrangeFox sources
+repo init --depth=1 -q -u https://gitlab.com/OrangeFox/Manifest.git -b fox_7.1
+repo sync -c -f -q --force-sync --no-clone-bundle --no-tags -j$(nproc --all)

--- a/setup/fox_8.1.sh
+++ b/setup/fox_8.1.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# OrangeFox building script by SebaUbuntu
+# OrangeFox repo sync script by TheSync
+# Sync OrangeFox sources for Android 8.1
+
+# Sync OrangeFox sources
+repo init --depth=1 -q -u https://gitlab.com/OrangeFox/Manifest.git -b fox_8.1
+repo sync -c -f -q --force-sync --no-clone-bundle --no-tags -j$(nproc --all)

--- a/setup/fox_9.0.sh
+++ b/setup/fox_9.0.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# OrangeFox building script by SebaUbuntu
+# OrangeFox repo sync script by TheSync
+# Sync OrangeFox sources for Android 9.0
+
+# Sync OrangeFox sources
+repo init --depth=1 -q -u https://gitlab.com/OrangeFox/Manifest.git -b fox_9.0
+repo sync -c -f -q --force-sync --no-clone-bundle --no-tags -j$(nproc --all)


### PR DESCRIPTION
This will make it easier for someone who will compile OrangeFox Recovery

Reference: https://wiki.orangefox.tech/en/dev/building